### PR TITLE
Add .travis.yml and build status badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: common-lisp
+sudo: required
+
+env:
+  matrix:
+    - LISP=sbcl
+    - LISP=ccl
+    - LISP=allegro
+
+install:
+  # Install cl-travis
+  - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+
+script:
+  - cl -l fiveam -l serapeum -l serapeum-tests
+       -e '(setf fiveam:*debug-on-error* t
+                 fiveam:*debug-on-failure* t)'
+       -e '(setf *debugger-hook*
+                 (lambda (c h)
+                   (declare (ignore c h))
+                   (uiop:quit -1)))'
+       -e '(serapeum.tests:run-tests)'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Overview
 
+[![Build Status](https://travis-ci.org/TBRSS/serapeum.svg?branch=master)](https://travis-ci.org/TBRSS/serapeum)
+
 Serapeum is a conservative library of Common Lisp utilities. It is a
 supplement, not a competitor, to [Alexandria][]. That means it is safe to
 do:


### PR DESCRIPTION
This PR adds a `.travis.yml` file to test the library on the cloud using SBCL, CCL and Allegro, and adds a build status badge to the README.