### PR TITLE
Add octet type on lispworks

### DIFF
--- a/types.lisp
+++ b/types.lisp
@@ -1,5 +1,9 @@
 (in-package :serapeum)
 
+#+lispworks
+(deftype octet ()
+  '(unsigned-byte 8))
+
 (deftype wholenum ()
   "A whole number. Equivalent to `(integer 0 *)'."
   '(integer 0 *))


### PR DESCRIPTION
Lispworks 7.0 can't load serapeum because it's missing the OCTET type specifier, this adds such a type specifier.  